### PR TITLE
Use relative import for API health route

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -5,7 +5,7 @@ from backend.approvals.router import router as approvals_router
 from backend.audit.router import router as audit_router
 from backend.native_registry.router import router as native_registry_router
 from backend.tribal_core import router as core_router
-from app.api.routes import health
+from .routes import health
 
 api_router = APIRouter()
 


### PR DESCRIPTION
## Summary
- switch `health` import to relative path for package-local reference
- add newline at end of `backend/app/api/__init__.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bceab286148325a2fdbd3af413b7e0