### PR TITLE
Consolidate /health endpoint in tribal_core router

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -4,8 +4,7 @@ from backend.tenants.router import router as tenants_router
 from backend.approvals.router import router as approvals_router
 from backend.audit.router import router as audit_router
 from backend.native_registry.router import router as native_registry_router
-from backend.tribal_core import router as core_router
-from .routes import health
+from backend.tribal_core import router as core_router, health_router
 
 api_router = APIRouter()
 
@@ -14,4 +13,4 @@ api_router.include_router(tenants_router)
 api_router.include_router(approvals_router)
 api_router.include_router(audit_router)
 api_router.include_router(native_registry_router)
-api_router.include_router(health.router)
+api_router.include_router(health_router)

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -1,8 +1,0 @@
-from fastapi import APIRouter
-
-# router = APIRouter(prefix="/routes", tags=["health"])
-router = APIRouter(tags=["health"])
-
-@router.get("/health")
-def health():
-    return {"status": "ok"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -31,10 +31,6 @@ from backend.app.common.auth import (
 
 # ---- Routers (align to your tree)
 from backend.app.api import api_router
-
-codex/decide-and-finalize-/health-implementation
-
-main
 from backend.tribal_core import (
     # router as core_router,
     register_events as core_register,
@@ -103,12 +99,6 @@ app.add_middleware(
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
-codex/decide-and-finalize-/health-implementation
-# API routers
-app.include_router(api_router)
-
-
-main
 # DB/table creation + seeding at startup (from core)
 core_register(app)
 
@@ -289,9 +279,6 @@ def require_admin(request: Request, db: SASession):
 
 
 # ---------- Routes (API / JSON) ----------
-# @app.get("/health")
-# def health():
-#     return {"ok": True}
 
 
 @app.get("/tribes", response_model=List[Tribe])

--- a/backend/tests/test_imports.py
+++ b/backend/tests/test_imports.py
@@ -14,7 +14,6 @@ MODULES = [
     "approvals",
     "audit",
     "app.api",
-    "app.api.routes",
     "native_registry.appy",
     "tribal_core",
 ]

--- a/backend/tribal_core.py
+++ b/backend/tribal_core.py
@@ -550,9 +550,16 @@ class PersonNameOut(BaseModel):
 
 
 # ==========================
-# FastAPI router
+# FastAPI routers
 # ==========================
 router = APIRouter(prefix="/core", tags=["core"])
+health_router = APIRouter(tags=["health"])
+
+
+@health_router.get("/health")
+def health() -> dict[str, str]:
+    """Basic service health check."""
+    return {"status": "ok"}
 
 
 # Dependency: DB session per request


### PR DESCRIPTION
## Summary
- define `/health` route within `tribal_core` and export `health_router`
- remove old `app.api.routes` module and update API router imports
- adjust import tests for removed module

## Testing
- `pytest`
- `uvicorn backend.main:app` & `curl -i http://localhost:8000/health`


------
https://chatgpt.com/codex/tasks/task_b_68bceed0beac8325ae8472f586d0d862