### PR TITLE
chore: clean unused imports

### DIFF
--- a/backend/native_registry/appy.py
+++ b/backend/native_registry/appy.py
@@ -16,11 +16,11 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, List
 
-from fastapi import FastAPI, Depends, HTTPException, Query, Form
+from fastapi import FastAPI, Depends, HTTPException, Query
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi import Request
-from pydantic import BaseModel, HttpUrl, Field
+from pydantic import BaseModel, Field
 from sqlalchemy import (
     create_engine, ForeignKey, String, Integer, Text, DateTime, Enum as SAEnum,
     UniqueConstraint, Index, Boolean, Float, CheckConstraint
@@ -28,6 +28,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import (
     DeclarativeBase, Mapped, mapped_column, relationship, Session, sessionmaker
 )
+import re
+import os
 
 # -----------------------------------------------------------------------------
 # DB setup
@@ -283,7 +285,6 @@ def get_db():
 # -----------------------------------------------------------------------------
 # Utility: slugify
 # -----------------------------------------------------------------------------
-import re
 
 def slugify(value: str) -> str:
     value = re.sub(r"[^a-zA-Z0-9\s-]", "", value).strip().lower()
@@ -758,7 +759,6 @@ layout_html = """
 # -----------------------------------------------------------------------------
 # Helper to materialize templates to disk on startup (dev convenience)
 # -----------------------------------------------------------------------------
-import os
 
 TEMPLATE_DIR = os.path.join(os.getcwd(), "templates")
 os.makedirs(TEMPLATE_DIR, exist_ok=True)

--- a/backend/scripts/clean_templates.py
+++ b/backend/scripts/clean_templates.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 TEMPLATES_DIR = Path(__file__).resolve().parents[1] / "templates"


### PR DESCRIPTION
## Summary
- drop unused `Form` and `HttpUrl` imports and centralize `re`/`os` in `native_registry/appy`
- remove unused `os` import from `clean_templates` script

## Testing
- `ruff check .` (fails: 39 errors)
- `mypy .` (fails: missing qrcode stubs and duplicate module path)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68bcf35becd083259b881cf3d0adb72e