### PR TITLE
Fix admin membership template path to match existing file

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -522,7 +522,7 @@ async def admin_memberships(request: Request, db: SASession = Depends(core_get_d
         .all()
     )
     return templates.TemplateResponse(
-        "admin_memberships.html", {"request": request, "pending": pending}
+        "admin_membership.html", {"request": request, "pending": pending}
     )
 
 


### PR DESCRIPTION
## Summary
- Fix admin memberships route to use existing `admin_membership.html` template

## Testing
- `python - <<'PY'
from fastapi.testclient import TestClient
from backend.main import app
from backend.tribal_core import SessionLocal, User
from backend.app.common.auth import hash_password
client = TestClient(app)
with client:
    db = SessionLocal()
    admin = User(username='admin', email='admin@example.com', password=hash_password('secret'), role='admin')
    db.add(admin); db.commit(); db.refresh(admin); db.close()
    resp_login = client.post('/login', data={'email': 'admin@example.com', 'password': 'secret'})
    print('login status:', resp_login.status_code)
    resp_admin = client.get('/admin/memberships')
    print('admin status:', resp_admin.status_code)
    print(resp_admin.text.splitlines()[0:5])
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68be450c4554832588163a53c91730c2