### PR TITLE
Add native registry routes

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -3,7 +3,9 @@ from fastapi import APIRouter
 from backend.tenants.router import router as tenants_router
 from backend.approvals.router import router as approvals_router
 from backend.audit.router import router as audit_router
-from backend.native_registry.router import router as native_registry_router
+from backend.native_registry.router import (
+    router as native_registry_router,
+)
 from backend.tribal_core import router as core_router, health_router
 
 api_router = APIRouter()

--- a/backend/native_registry/router.py
+++ b/backend/native_registry/router.py
@@ -1,7 +1,91 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from .appy import (
+    Category,
+    SubCategory,
+    Business,
+    BusinessSubCategory,
+    ReviewStatus,
+    templates,
+    get_db,
+)
 
 router = APIRouter(prefix="/native-registry", tags=["native_registry"])
 
+
 @router.get("")
-def list_native_registry_items():
-    return {"items": []}
+def home(request: Request, db: Session = Depends(get_db)):
+    categories = db.query(Category).order_by(Category.name).all()
+    return templates.TemplateResponse("home.html", {"request": request, "categories": categories})
+
+
+@router.get("/c/{category_slug}")
+def view_category(category_slug: str, request: Request, db: Session = Depends(get_db)):
+    cat = db.query(Category).filter_by(slug=category_slug).one_or_none()
+    if not cat:
+        raise HTTPException(404, "Category not found")
+    subcats = (
+        db.query(SubCategory)
+        .filter_by(category_id=cat.id)
+        .order_by(SubCategory.name)
+        .all()
+    )
+    return templates.TemplateResponse(
+        "category.html", {"request": request, "category": cat, "subcategories": subcats}
+    )
+
+
+@router.get("/s/{subcategory_slug}")
+def view_subcategory(
+    subcategory_slug: str, request: Request, db: Session = Depends(get_db)
+):
+    sub = db.query(SubCategory).filter_by(slug=subcategory_slug).one_or_none()
+    if not sub:
+        raise HTTPException(404, "Subcategory not found")
+    bs_ids = [
+        bs.business_id
+        for bs in db.query(BusinessSubCategory).filter_by(subcategory_id=sub.id).all()
+    ]
+    businesses = []
+    if bs_ids:
+        businesses = (
+            db.query(Business)
+            .filter(Business.id.in_(bs_ids))
+            .order_by(Business.name)
+            .all()
+        )
+    return templates.TemplateResponse(
+        "subcategory.html",
+        {"request": request, "subcategory": sub, "businesses": businesses},
+    )
+
+
+@router.get("/b/{slug}")
+def view_business(slug: str, request: Request, db: Session = Depends(get_db)):
+    biz = db.query(Business).filter_by(slug=slug).one_or_none()
+    if not biz:
+        raise HTTPException(404, "Business not found")
+    avg = None
+    if biz.reviews:
+        avg = round(
+            sum(r.rating for r in biz.reviews if r.status == ReviewStatus.approved)
+            / max(
+                1,
+                len([r for r in biz.reviews if r.status == ReviewStatus.approved]),
+            ),
+            2,
+        )
+    return templates.TemplateResponse(
+        "business.html",
+        {
+            "request": request,
+            "business": biz,
+            "avg_rating": avg,
+            "reviews": [r for r in biz.reviews if r.status == ReviewStatus.approved],
+            "media": biz.media,
+            "legal_links": biz.links,
+            "compliance": biz.compliance,
+            "size_feedback": biz.size_feedback,
+        },
+    )


### PR DESCRIPTION
## Summary
- add router functions for native business registry pages
- register native registry routes with core API router

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68be4515a40083259139058ad0d3cfbb