### PR TITLE
Add native registry routes

### DIFF
--- a/backend/native_registry/router.py
+++ b/backend/native_registry/router.py
@@ -9,9 +9,20 @@ from .appy import (
     ReviewStatus,
     templates,
     get_db,
+    Base,
+    engine,
+    SessionLocal,
+    seed_taxonomy,
 )
 
 router = APIRouter(prefix="/native-registry", tags=["native_registry"])
+
+
+@router.on_event("startup")
+def init_schema():
+    Base.metadata.create_all(engine)
+    with SessionLocal() as db:
+        seed_taxonomy(db)
 
 
 @router.get("")


### PR DESCRIPTION
## Summary
- add router functions for native business registry pages
- register native registry routes with core API router
- initialize native registry schema and seed data on API startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68be4fb452508325a655ee3531e2b5cc