### PR TITLE
Fix mypy qrcode stub error by adding types-qrcode

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ python-dotenv==1.1.1
 python-multipart==0.0.20
 PyYAML==6.0.2
 qrcode==8.2
+types-qrcode==8.2.0.20250506
 sniffio==1.3.1
 SQLAlchemy==2.0.43
 starlette==0.46.2


### PR DESCRIPTION
## Summary
- add `types-qrcode` stub package to backend requirements
- install stubs to satisfy mypy

## Testing
- `mypy backend/native_registry/scratch_qr.py`

------
https://chatgpt.com/codex/tasks/task_b_68be45182db08325aa139f719c0d2ba4