### PR TITLE
Implement fallback in tribe list fetch logic

### DIFF
--- a/backend/templates/tribe_list.html
+++ b/backend/templates/tribe_list.html
@@ -52,14 +52,22 @@
       params.set('sort', sort);
       params.set('limit', 500);
 
-      const r = await fetch(`/api/core/tribes?${params.toString()}`);
-      if (!r.ok) throw new Error('Failed to load tribes');
+      let r;
+      try {
+        r = await fetch(`/tribes?${params.toString()}`);
+        if (!r.ok) {
+          r = await fetch(`/api/core/tribes?${params.toString()}`);
+        }
+      } catch (e) {
+        // ignore to handle below
+      }
+      if (!r || !r.ok) throw new Error('Unable to load tribes');
       TRIBES = await r.json();
 
       render();
       status.textContent = `${TRIBES.length} tribe${TRIBES.length===1?'':'s'} found`;
     } catch (e) {
-      list.innerHTML = `<li class="text-danger">Error: ${e.message}</li>`;
+      list.innerHTML = '<li class="text-danger">Unable to load tribes. Please try again later.</li>';
     }
   }
 


### PR DESCRIPTION
## Summary
- Try the in-memory `/tribes` endpoint before falling back to `/api/core/tribes` in tribe list
- Show a user-friendly message when both endpoints fail

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68be5f60485c8325a9806d2f3f7cc541